### PR TITLE
Added the `finality_checkpoints` route

### DIFF
--- a/beacon/api/routes.go
+++ b/beacon/api/routes.go
@@ -5,14 +5,15 @@ const (
 	ValidatorID string = "validator_id"
 
 	// Beacon API routes
-	ValidatorsRouteTemplate string = "v1/beacon/states/%s/validators"
-	ValidatorsRoute         string = "v1/beacon/states/{state_id}/validators"
-	ValidatorRouteTemplate  string = "v1/beacon/states/%s/validators/%s"
-	ValidatorRoute          string = "v1/beacon/states/{state_id}/validators/{validator_id}"
-	SyncingRoute            string = "v1/node/syncing"
-	DepositContractRoute    string = "v1/config/deposit_contract"
-	ConfigSpecRoute         string = "v1/config/spec"
-	BeaconGenesisRoute      string = "v1/beacon/genesis"
+	ValidatorsRouteTemplate  string = "v1/beacon/states/%s/validators"
+	ValidatorsRoute          string = "v1/beacon/states/{state_id}/validators"
+	ValidatorRouteTemplate   string = "v1/beacon/states/%s/validators/%s"
+	ValidatorRoute           string = "v1/beacon/states/{state_id}/validators/{validator_id}"
+	SyncingRoute             string = "v1/node/syncing"
+	DepositContractRoute     string = "v1/config/deposit_contract"
+	ConfigSpecRoute          string = "v1/config/spec"
+	BeaconGenesisRoute       string = "v1/beacon/genesis"
+	FinalityCheckpointsRoute string = "v1/beacon/states/{state_id}/finality_checkpoints"
 
 	// Admin routes
 	AddValidatorRoute   string = "add-validator"

--- a/beacon/db/config.go
+++ b/beacon/db/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	DefaultChainID                      uint64 = 0x90de5e7
+	DefaultChainID                      uint64 = 31337
 	DefaultDepositContractAddressString string = "0xde905175eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 )
 

--- a/beacon/server/get-finality-checkpoints.go
+++ b/beacon/server/get-finality-checkpoints.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/nodeset-org/osha/beacon/api"
+)
+
+// Handle a get finality checkpoints request
+func (s *BeaconMockServer) getFinalityCheckpoints(w http.ResponseWriter, r *http.Request) {
+	// Get the request vars
+	vars := mux.Vars(r)
+	state, exists := vars[api.StateID]
+	if !exists {
+		handleInputError(s.logger, w, fmt.Errorf("missing state ID"))
+		return
+	}
+	/*
+		if state != "head" {
+			handleInputError(s.logger, w, fmt.Errorf("unsupported state ID [%s], only 'head' is supported", state))
+			return
+		}
+	*/
+
+	// Get the response
+	response, err := s.manager.Beacon_FinalityCheckpoints(context.Background(), state)
+	if err != nil {
+		handleInputError(s.logger, w, err)
+		return
+	}
+	handleSuccess(s.logger, w, response)
+}

--- a/beacon/server/get-validator.go
+++ b/beacon/server/get-validator.go
@@ -13,15 +13,17 @@ func (s *BeaconMockServer) getValidator(w http.ResponseWriter, r *http.Request) 
 	// Get the request vars
 	_ = s.processApiRequest(w, r, nil)
 	vars := mux.Vars(r)
-	state, exists := vars[api.StateID]
-	if !exists {
-		handleInputError(s.logger, w, fmt.Errorf("missing state ID"))
-		return
-	}
-	if state != "head" {
-		handleInputError(s.logger, w, fmt.Errorf("unsupported state ID [%s], only 'head' is supported", state))
-		return
-	}
+	/*
+		state, exists := vars[api.StateID]
+		if !exists {
+			handleInputError(s.logger, w, fmt.Errorf("missing state ID"))
+			return
+		}
+		if state != "head" {
+			handleInputError(s.logger, w, fmt.Errorf("unsupported state ID [%s], only 'head' is supported", state))
+			return
+		}
+	*/
 
 	id, exists := vars[api.ValidatorID]
 	if !exists {

--- a/beacon/server/get-validators.go
+++ b/beacon/server/get-validators.go
@@ -26,10 +26,12 @@ func (s *BeaconMockServer) getValidators(w http.ResponseWriter, r *http.Request)
 		handleInputError(s.logger, w, fmt.Errorf("missing state ID"))
 		return
 	}
-	if state != "head" {
-		handleInputError(s.logger, w, fmt.Errorf("unsupported state ID [%s], only 'head' is supported", state))
-		return
-	}
+	/*
+		if state != "head" {
+			handleInputError(s.logger, w, fmt.Errorf("unsupported state ID [%s], only 'head' is supported", state))
+			return
+		}
+	*/
 
 	var ids []string
 	switch r.Method {

--- a/beacon/server/server.go
+++ b/beacon/server/server.go
@@ -138,6 +138,14 @@ func (s *BeaconMockServer) registerApiRoutes(apiRouter *mux.Router) {
 			handleInvalidMethod(s.logger, w)
 		}
 	})
+	apiRouter.HandleFunc("/"+api.FinalityCheckpointsRoute, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			s.getFinalityCheckpoints(w, r)
+		default:
+			handleInvalidMethod(s.logger, w)
+		}
+	})
 }
 
 // Admin routes


### PR DESCRIPTION
This adds the `v1/beacon/states/{state_id}/finality_checkpoints` route and removes the state checks for validators.