### PR TITLE
Adds endpoint for setting the activation epoch on a per validator basis

### DIFF
--- a/beacon/Dockerfile
+++ b/beacon/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.22.5
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod tidy
+
+COPY . .
+RUN cd beacon && go build -o /beacon
+
+EXPOSE 48812
+
+ENTRYPOINT ["/beacon"]

--- a/beacon/api/routes.go
+++ b/beacon/api/routes.go
@@ -16,10 +16,11 @@ const (
 	FinalityCheckpointsRoute string = "v1/beacon/states/{state_id}/finality_checkpoints"
 
 	// Admin routes
-	AddValidatorRoute   string = "add-validator"
-	CommitBlockRoute    string = "commit-block"
-	SetBalanceRoute     string = "set-balance"
-	SetStatusRoute      string = "set-status"
-	SetHighestSlotRoute string = "set-highest-slot"
-	SlashRoute          string = "slash"
+	AddValidatorRoute       string = "add-validator"
+	CommitBlockRoute        string = "commit-block"
+	SetBalanceRoute         string = "set-balance"
+	SetStatusRoute          string = "set-status"
+	SetActivationEpochRoute string = "set-activation-epoch"
+	SetHighestSlotRoute     string = "set-highest-slot"
+	SlashRoute              string = "slash"
 )

--- a/beacon/db/validator.go
+++ b/beacon/db/validator.go
@@ -56,6 +56,10 @@ func (v *Validator) SetStatus(status beacon.ValidatorState) {
 	v.Status = status
 }
 
+func (v *Validator) SetActivationEpoch(epoch uint64) {
+	v.ActivationEpoch = epoch
+}
+
 func (v *Validator) Slash(penaltyGwei uint64) error {
 	if v.Status != beacon.ValidatorState_ActiveOngoing && v.Status != beacon.ValidatorState_ActiveExiting {
 		return fmt.Errorf("validator with pubkey %s is not in a slashable state", v.Pubkey.HexWithPrefix())

--- a/beacon/server/server.go
+++ b/beacon/server/server.go
@@ -182,6 +182,14 @@ func (s *BeaconMockServer) registerAdminRoutes(adminRouter *mux.Router) {
 			handleInvalidMethod(s.logger, w)
 		}
 	})
+	adminRouter.HandleFunc("/"+api.SetActivationEpochRoute, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			s.setActivationEpoch(w, r)
+		default:
+			handleInvalidMethod(s.logger, w)
+		}
+	})
 	adminRouter.HandleFunc("/"+api.SlashRoute, func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:

--- a/beacon/server/set-activation-epoch.go
+++ b/beacon/server/set-activation-epoch.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+func (s *BeaconMockServer) setActivationEpoch(w http.ResponseWriter, r *http.Request) {
+	// Get the request vars
+	args := s.processApiRequest(w, r, nil)
+	id, exists := args["id"]
+	if !exists {
+		handleInputError(s.logger, w, fmt.Errorf("missing validator ID"))
+		return
+	}
+	epochString, exists := args["epoch"]
+	if !exists {
+		handleInputError(s.logger, w, fmt.Errorf("missing epoch"))
+		return
+	}
+
+	// Input validation
+
+	epoch, err := strconv.ParseUint(epochString[0], 10, 64)
+	if err != nil {
+		handleInputError(s.logger, w, fmt.Errorf("invalid epoch [%s]", epochString[0]))
+		return
+
+	}
+
+	// Get the validator
+	validator, err := s.manager.GetValidator(id[0])
+	if err != nil {
+		handleInputError(s.logger, w, err)
+		return
+	}
+
+	// Set the status
+	validator.SetActivationEpoch(epoch)
+	handleSuccess(s.logger, w, nil)
+}

--- a/beacon/server/set-activation-epoch_test.go
+++ b/beacon/server/set-activation-epoch_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/nodeset-org/osha/beacon/api"
+	idb "github.com/nodeset-org/osha/beacon/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// Test setting a validator's status
+func TestSetActivationEpoch(t *testing.T) {
+	activationEpoch := uint64(1100)
+
+	// Take a snapshot
+	server.manager.TakeSnapshot("test")
+	defer func() {
+		err := server.manager.RevertToSnapshot("test")
+		if err != nil {
+			t.Fatalf("error reverting to snapshot: %v", err)
+		}
+	}()
+
+	// Provision the database
+	d := idb.ProvisionDatabaseForTesting(t, logger)
+	server.manager.SetDatabase(d)
+	v1 := d.GetValidatorByIndex(1)
+	id := v1.Pubkey.HexWithPrefix()
+
+	// Send the set status request
+	sendSetActivationEpochRequest(t, id, activationEpoch)
+
+	// Get the validator's status now
+	parsedResponse := getValidatorResponse(t, id)
+
+	// Make sure the response is correct
+	require.Equal(t, activationEpoch, uint64(parsedResponse.Data.Validator.ActivationEpoch))
+	t.Logf("Received correct response - status: %d", parsedResponse.Data.Validator.ActivationEpoch)
+}
+
+func sendSetActivationEpochRequest(t *testing.T, id string, epoch uint64) {
+	// Create the request
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/admin/%s", port, api.SetActivationEpochRoute), nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+	query := request.URL.Query()
+	query.Add("id", id)
+	query.Add("epoch", strconv.FormatUint(epoch, 10))
+	request.URL.RawQuery = query.Encode()
+	t.Logf("Created request")
+
+	// Send the request
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("error sending request: %v", err)
+	}
+	t.Logf("Sent request")
+
+	// Check the status code
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	t.Logf("Received OK status code")
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
-  mock-eth-bn:
-    image: threevl/mock-eth-bn:0.0.2
+  osha:
+    image: nodeset/osha:0.0.1
     build:
       context: .
       dockerfile: ./beacon/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  mock-eth-bn:
+    image: threevl/mock-eth-bn:0.0.2
+    build:
+      context: .
+      dockerfile: ./beacon/Dockerfile


### PR DESCRIPTION
Follow the same process as the set-status route, this PR adds a set-activation-epoch route that allows the user to set the activation epoch that should be returned for a given validator.